### PR TITLE
Add a bunch of competition endpoints

### DIFF
--- a/docs/competition/challenges/challenge.md
+++ b/docs/competition/challenges/challenge.md
@@ -1,0 +1,60 @@
+---
+name: Get challenge
+
+url: https://competition.trackmania.nadeo.club
+method: GET
+route: /api/challenges/{challengeId}
+
+audience: NadeoClubServices
+
+parameters:
+  path:
+    - name: challengeId
+      type: string
+      description: A valid challenge ID
+      required: true
+---
+
+Gets challenge details for a challenge ID.
+
+---
+
+**Remarks**:
+- Note that challenges are different from competitions - challenges are separate leaderboard structures that can be part of a competition (for example in the form of a qualifying session).
+
+---
+
+**Example request**:
+```plain
+GET https://competition.trackmania.nadeo.club/api/challenges/409
+```
+
+**Example response**:
+```json
+{
+    "id": 409,
+    "uid": "8c4a18cc-dca7-4fe2-8dc3-55e40120ad26",
+    "name": "Cup of the Day 2021-08-14 #2 - Challenge",
+    "scoreDirection": "ASC",
+    "startDate": 1628989260,
+    "endDate": 1628990160,
+    "status": "SERVER_DELETED",
+    "resultsVisibility": "PUBLIC",
+    "creator": "afe7e1c1-7086-48f7-bde9-a7e320647510",
+    "admins": [
+        "0060a0c1-2e62-41e7-9db7-c86236af3ac4",
+        "54e4dda4-522d-496f-8a8b-fe0d0b5a2a8f",
+        "2116b392-d808-4264-923f-2bfcfa60a570",
+        "6ce163d5-f240-4741-870b-f2adad843865"
+    ],
+    "nbServers": 0,
+    "autoScale": true,
+    "nbMaps": 1,
+    "leaderboardId": 2003,
+    "deletedOn": null,
+    "leaderboardType": "SUM",
+    "completeTimeout": 5
+}
+```
+
+If a `challengeId` is invalid, the response will contain a `404` response code.

--- a/docs/competition/challenges/challenges.md
+++ b/docs/competition/challenges/challenges.md
@@ -1,0 +1,115 @@
+---
+name: Get challenges
+
+url: https://competition.trackmania.nadeo.club
+method: GET
+route: /api/challenges?length={length}&offset={offset}
+
+audience: NadeoClubServices
+
+parameters:
+  query:
+    - name: length
+      type: integer
+      description: The number of challenges to retrieve (10 by default)
+      required: false
+    - name: offset
+      type: integer
+      description: The number of challenges to skip
+      required: false
+---
+
+Gets a list of challenges.
+
+---
+
+**Remarks**:
+- Note that challenges are different from competitions - challenges are separate leaderboard structures that can be part of a competition (for example in the form of a qualifying session).
+
+---
+
+**Example request**:
+```plain
+GET https://competition.trackmania.nadeo.club/api/challenges?length=3
+```
+
+**Example response**:
+```json
+[
+    {
+        "id": 2388,
+        "uid": "07f3ff0b-fc51-47ed-8b98-0380a8824d99",
+        "name": "COTD 2023-02-07 #3 - Challenge",
+        "scoreDirection": "ASC",
+        "startDate": 1675850460,
+        "endDate": 1675851360,
+        "status": "INIT",
+        "resultsVisibility": "PUBLIC",
+        "creator": "afe7e1c1-7086-48f7-bde9-a7e320647510",
+        "admins": [
+            "0060a0c1-2e62-41e7-9db7-c86236af3ac4",
+            "54e4dda4-522d-496f-8a8b-fe0d0b5a2a8f",
+            "2116b392-d808-4264-923f-2bfcfa60a570",
+            "6ce163d5-f240-4741-870b-f2adad843865",
+            "a76653e1-998a-4c53-8a91-0a396e15bfb5"
+        ],
+        "nbServers": 0,
+        "autoScale": false,
+        "nbMaps": 1,
+        "leaderboardId": 12307,
+        "deletedOn": null,
+        "leaderboardType": "SUM",
+        "completeTimeout": 5
+    },
+    {
+        "id": 2387,
+        "uid": "73650840-53eb-4921-a193-70b26f0ac789",
+        "name": "COTD 2023-02-07 #2 - Challenge",
+        "scoreDirection": "ASC",
+        "startDate": 1675821660,
+        "endDate": 1675822560,
+        "status": "INIT",
+        "resultsVisibility": "PUBLIC",
+        "creator": "afe7e1c1-7086-48f7-bde9-a7e320647510",
+        "admins": [
+            "0060a0c1-2e62-41e7-9db7-c86236af3ac4",
+            "54e4dda4-522d-496f-8a8b-fe0d0b5a2a8f",
+            "2116b392-d808-4264-923f-2bfcfa60a570",
+            "6ce163d5-f240-4741-870b-f2adad843865",
+            "a76653e1-998a-4c53-8a91-0a396e15bfb5"
+        ],
+        "nbServers": 0,
+        "autoScale": false,
+        "nbMaps": 1,
+        "leaderboardId": 12304,
+        "deletedOn": null,
+        "leaderboardType": "SUM",
+        "completeTimeout": 5
+    },
+    {
+        "id": 2386,
+        "uid": "063f5cfc-ade1-456e-9db3-f5ba3d4c8d3a",
+        "name": "COTD 2023-02-07 #1 - Challenge",
+        "scoreDirection": "ASC",
+        "startDate": 1675792860,
+        "endDate": 1675793760,
+        "status": "HAS_SERVERS",
+        "resultsVisibility": "PUBLIC",
+        "creator": "afe7e1c1-7086-48f7-bde9-a7e320647510",
+        "admins": [
+            "0060a0c1-2e62-41e7-9db7-c86236af3ac4",
+            "54e4dda4-522d-496f-8a8b-fe0d0b5a2a8f",
+            "2116b392-d808-4264-923f-2bfcfa60a570",
+            "6ce163d5-f240-4741-870b-f2adad843865",
+            "a76653e1-998a-4c53-8a91-0a396e15bfb5"
+        ],
+        "nbServers": 0,
+        "autoScale": false,
+        "nbMaps": 1,
+        "leaderboardId": 12301,
+        "deletedOn": null,
+        "leaderboardType": "SUM",
+        "completeTimeout": 5
+    }
+]
+```

--- a/docs/competition/challenges/leaderboard.md
+++ b/docs/competition/challenges/leaderboard.md
@@ -1,0 +1,122 @@
+---
+name: Get challenge leaderboard
+
+url: https://competition.trackmania.nadeo.club
+method: GET
+route: /api/challenges/{challengeId}/leaderboard?length={length}&offset={offset}
+
+audience: NadeoClubServices
+
+parameters:
+  path:
+    - name: challengeId
+      type: string
+      description: A valid challenge ID
+      required: true
+  query:
+    - name: length
+      type: integer
+      description: The number of leaderboard entries to retrieve
+      required: false
+    - name: offset
+      type: integer
+      description: The number of leaderboard entries to skip
+      required: false
+---
+
+Gets leaderboard entries for a challenge ID.
+
+---
+
+**Remarks**:
+- Note that challenges are different from competitions - challenges are separate leaderboard structures that can be part of a competition (for example in the form of a qualifying session).
+
+---
+
+**Example request**:
+```plain
+GET https://competition.trackmania.nadeo.club/api/challenges/409/leaderboard
+```
+
+**Example response**:
+```json
+{
+    "challengeId": 409,
+    "cardinal": 399,
+    "scoreUnit": "time",
+    "results": [
+        {
+            "points": 38106,
+            "player": "b90e91eb-bd87-41fd-8c69-6560dbeedd2e",
+            "score": 38106,
+            "rank": 1,
+            "zone": "World|Europe|Poland|Kujawsko-Pomorskie"
+        },
+        {
+            "points": 38156,
+            "player": "dade4799-0761-41b7-8df1-cf413e5c8eef",
+            "score": 38156,
+            "rank": 2,
+            "zone": "World|Asia|Brunei"
+        },
+        {
+            "points": 38206,
+            "player": "d46fb45d-d422-47c9-9785-67270a311e25",
+            "score": 38206,
+            "rank": 3,
+            "zone": "World|Europe|Czechia|Středočeský kraj"
+        },
+        {
+            "points": 38251,
+            "player": "8f08302a-f670-463b-9f71-fbfacffb8bd1",
+            "score": 38251,
+            "rank": 4,
+            "zone": "World|Europe|Germany|Saarland|Saarbrücken"
+        },
+        {
+            "points": 38252,
+            "player": "70bd004b-b948-4a9c-9013-4282487f035b",
+            "score": 38252,
+            "rank": 5,
+            "zone": "World|Europe|France|Nouvelle-Aquitaine|Pyrénées-Atlantiques"
+        },
+        {
+            "points": 38264,
+            "player": "5c78b27a-908e-41f5-bce7-09e4367dbc0d",
+            "score": 38264,
+            "rank": 6,
+            "zone": "World|North America|United States|Wisconsin"
+        },
+        {
+            "points": 38278,
+            "player": "9688a134-3562-470c-a06d-2275da464643",
+            "score": 38278,
+            "rank": 7,
+            "zone": "World|Europe|Finland"
+        },
+        {
+            "points": 38308,
+            "player": "70e6f70b-5670-48d8-8551-fb8bb5181f03",
+            "score": 38308,
+            "rank": 8,
+            "zone": "World|North America|Jamaica"
+        },
+        {
+            "points": 38321,
+            "player": "6b14adfa-90d6-486f-8c32-66756d4c93d5",
+            "score": 38321,
+            "rank": 9,
+            "zone": "World|Europe|Poland|Lubelskie"
+        },
+        {
+            "points": 38331,
+            "player": "fcae33dd-70f2-4da1-b493-cd77c4399d0e",
+            "score": 38331,
+            "rank": 10,
+            "zone": "World|South America|Brazil|São Paulo"
+        }
+    ]
+}
+```
+
+If a `challengeId` is invalid, the response will contain a `404` response code.

--- a/docs/competition/challenges/map-records.md
+++ b/docs/competition/challenges/map-records.md
@@ -1,0 +1,122 @@
+---
+name: Get challenge map records
+
+url: https://competition.trackmania.nadeo.club
+method: GET
+route: /api/challenges/{challengeId}/records/maps/{mapUid}?length={length}&offset={offset}
+
+audience: NadeoClubServices
+
+parameters:
+  path:
+    - name: challengeId
+      type: string
+      description: A valid challenge ID
+      required: true
+    - name: mapUid
+      type: string
+      description: A valid map UID
+      required: true
+  query:
+    - name: length
+      type: integer
+      description: The number of records to retrieve (10 by default)
+      required: false
+    - name: offset
+      type: integer
+      description: The number of records to skip
+      required: false
+---
+
+Gets map records for a challenge ID.
+
+---
+
+**Remarks**:
+- Note that challenges are different from competitions - challenges are separate leaderboard structures that can be part of a competition (for example in the form of a qualifying session).
+- This endpoint can be very similar to the [challenge leaderboard endpoint](/competitions/challenges/leaderboard) - with the difference that you can retrieve map-specific rankings instead of the overall leaderboard.
+
+---
+
+**Example request**:
+```plain
+GET https://competition.trackmania.nadeo.club/api/challenges/409/records/maps/IM5eN8vx4kZfEedkLo2N5p548j3
+```
+
+**Example response**:
+```json
+[
+    {
+        "time": 38106,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "b90e91eb-bd87-41fd-8c69-6560dbeedd2e",
+        "score": 38106,
+        "rank": 1
+    },
+    {
+        "time": 38156,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "dade4799-0761-41b7-8df1-cf413e5c8eef",
+        "score": 38156,
+        "rank": 2
+    },
+    {
+        "time": 38206,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "d46fb45d-d422-47c9-9785-67270a311e25",
+        "score": 38206,
+        "rank": 3
+    },
+    {
+        "time": 38251,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "8f08302a-f670-463b-9f71-fbfacffb8bd1",
+        "score": 38251,
+        "rank": 4
+    },
+    {
+        "time": 38252,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "70bd004b-b948-4a9c-9013-4282487f035b",
+        "score": 38252,
+        "rank": 5
+    },
+    {
+        "time": 38264,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "5c78b27a-908e-41f5-bce7-09e4367dbc0d",
+        "score": 38264,
+        "rank": 6
+    },
+    {
+        "time": 38278,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "9688a134-3562-470c-a06d-2275da464643",
+        "score": 38278,
+        "rank": 7
+    },
+    {
+        "time": 38308,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "70e6f70b-5670-48d8-8551-fb8bb5181f03",
+        "score": 38308,
+        "rank": 8
+    },
+    {
+        "time": 38321,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "6b14adfa-90d6-486f-8c32-66756d4c93d5",
+        "score": 38321,
+        "rank": 9
+    },
+    {
+        "time": 38331,
+        "uid": "IM5eN8vx4kZfEedkLo2N5p548j3",
+        "player": "fcae33dd-70f2-4da1-b493-cd77c4399d0e",
+        "score": 38331,
+        "rank": 10
+    }
+]
+```
+
+If a `challengeId` is invalid, a `mapUid` is invalid, or there are no records for the combination of the two, the response will contain a `404` response code.

--- a/docs/competition/challenges/map-records.md
+++ b/docs/competition/challenges/map-records.md
@@ -34,7 +34,7 @@ Gets map records for a challenge ID.
 
 **Remarks**:
 - Note that challenges are different from competitions - challenges are separate leaderboard structures that can be part of a competition (for example in the form of a qualifying session).
-- This endpoint can be very similar to the [challenge leaderboard endpoint](/competitions/challenges/leaderboard) - with the difference that you can retrieve map-specific rankings instead of the overall leaderboard.
+- This endpoint can be very similar to the [challenge leaderboard endpoint](/competition/challenges/leaderboard) - with the difference that you can retrieve map-specific rankings instead of the overall leaderboard.
 
 ---
 

--- a/docs/competition/matches/matches-for-round.md
+++ b/docs/competition/matches/matches-for-round.md
@@ -28,6 +28,11 @@ Gets matches for a given round in a competition.
 
 ---
 
+**Remarks**:
+- Note that the match IDs in the response are competition match IDs to be used in [competition match endpoints](/competitions/matches) - they are not equivalent to the numerical match IDs used in the [club match endpoints](/club/matches). To use those endpoints based on the response from this endpoint, use the `clubMatchLiveId` field as an identifier.
+
+---
+
 **Example request**:
 ```plain
 GET https://competition.trackmania.nadeo.club/api/rounds/9078/matches

--- a/docs/competition/matches/participants.md
+++ b/docs/competition/matches/participants.md
@@ -1,0 +1,117 @@
+---
+name: Get competition match participants
+
+url: https://competition.trackmania.nadeo.club
+method: GET
+route: /api/matches/{compMatchId}/participants?length={length}&offset={offset}
+
+audience: NadeoClubServices
+
+parameters:
+  path:
+    - name: compMatchId
+      type: string
+      description: A valid competition match ID
+      required: true
+  query:
+    - name: length
+      type: integer
+      description: The number of participants to retrieve (10 by default)
+      required: false
+    - name: offset
+      type: integer
+      description: The number of participants to skip
+      required: false
+---
+
+Gets players for a given competition match ID.
+
+---
+
+**Remarks**:
+- This endpoint only supports competition match IDs, which are different from regular match IDs (as found in [the club matches endpoints](/club/matches)). They are numerical and have to be retrieved from a competition's rounds (see [here](/competition/matches/matches-for-round)).
+
+---
+
+**Example request**:
+```plain
+GET https://competition.trackmania.nadeo.club/api/matches/6899/participants
+```
+
+**Example response**:
+```json
+[
+    {
+        "participant": "e8b72453-7716-441e-9e72-14817d2e563a",
+        "matchId": 6899,
+        "rank": 1,
+        "score": 62,
+        "teamId": null
+    },
+    {
+        "participant": "8f08302a-f670-463b-9f71-fbfacffb8bd1",
+        "matchId": 6899,
+        "rank": 2,
+        "score": 61,
+        "teamId": null
+    },
+    {
+        "participant": "b09527f2-b61d-4d9a-8cdc-73484590f81f",
+        "matchId": 6899,
+        "rank": 3,
+        "score": 60,
+        "teamId": null
+    },
+    {
+        "participant": "af30b7a1-fc37-485f-94bf-f00e39805d8c",
+        "matchId": 6899,
+        "rank": 4,
+        "score": 59,
+        "teamId": null
+    },
+    {
+        "participant": "9da54743-020c-4e87-82b9-1dad80f8162d",
+        "matchId": 6899,
+        "rank": 5,
+        "score": 58,
+        "teamId": null
+    },
+    {
+        "participant": "05477e79-25fd-48c2-84c7-e1621aa46517",
+        "matchId": 6899,
+        "rank": 6,
+        "score": 57,
+        "teamId": null
+    },
+    {
+        "participant": "961d1145-8c7b-48c3-9191-0d1d91e44a4a",
+        "matchId": 6899,
+        "rank": 7,
+        "score": 56,
+        "teamId": null
+    },
+    {
+        "participant": "d0a811b4-5611-4948-8865-03c9d252bcf4",
+        "matchId": 6899,
+        "rank": 8,
+        "score": 55,
+        "teamId": null
+    },
+    {
+        "participant": "1336b019-0d7d-43f7-b227-ff336f8b7140",
+        "matchId": 6899,
+        "rank": 9,
+        "score": 54,
+        "teamId": null
+    },
+    {
+        "participant": "4d85c941-0242-4f9f-a6d4-ee7772d95e82",
+        "matchId": 6899,
+        "rank": 10,
+        "score": 53,
+        "teamId": null
+    }
+]
+```
+
+If a `compMatchId` is invalid, the response will contain a `404` response code.

--- a/docs/competition/matches/player-matches.md
+++ b/docs/competition/matches/player-matches.md
@@ -25,7 +25,7 @@ Gets matches for a player in the context of a competition.
 
 **Remarks**:
 - There are two different competition IDs which are both supported by this endpoint - the primary `id` is always numerical, while the `liveId` is a string typically starting with `"LID-COMP-`.
-- For team-based competitions, the team information and match results don't seem to be correct. Use [the match results endpoint](/club/matches/results) to get the actual results.
+- For team-based competitions, the team information and match results may not be correct. Use [the match results endpoint](/club/matches/results) to get the actual results.
 
 ---
 

--- a/docs/competition/matches/results.md
+++ b/docs/competition/matches/results.md
@@ -1,0 +1,125 @@
+---
+name: Get competition match results
+
+url: https://competition.trackmania.nadeo.club
+method: GET
+route: /api/matches/{compMatchId}/results?length={length}&offset={offset}
+
+audience: NadeoClubServices
+
+parameters:
+  path:
+    - name: compMatchId
+      type: string
+      description: A valid competition match ID
+      required: true
+  query:
+    - name: length
+      type: integer
+      description: The number of results to retrieve (10 by default)
+      required: false
+    - name: offset
+      type: integer
+      description: The number of results to skip
+      required: false
+---
+
+Gets results for a given competition match ID.
+
+---
+
+**Remarks**:
+- This endpoint only supports competition match IDs, which are different from regular match IDs (as found in [the club matches endpoints](/club/matches)). They are numerical and have to be retrieved from a competition's rounds (see [here](/competition/matches/matches-for-round)).
+- If the match does not use teams, the `teams` field will be an empty array, and the `teamPosition` field for each player will be `null`.
+- For proper team mappings and team names, refer to [the competition teams endpoint](/competition/competitions/teams).
+
+---
+
+**Example request**:
+```plain
+GET https://competition.trackmania.nadeo.club/api/matches/6899/results
+```
+
+**Example response**:
+```json
+{
+    "matchLiveId": "LID-MTCH-zplknskyw35qrqy",
+    "roundPosition": 0,
+    "results": [
+        {
+            "participant": "e8b72453-7716-441e-9e72-14817d2e563a",
+            "rank": 1,
+            "score": 62,
+            "zone": "World|Europe|France|Pays-de-la-Loire|Vendée",
+            "team": null
+        },
+        {
+            "participant": "8f08302a-f670-463b-9f71-fbfacffb8bd1",
+            "rank": 2,
+            "score": 61,
+            "zone": "World|Europe|Germany|Saarland|Saarbrücken",
+            "team": null
+        },
+        {
+            "participant": "b09527f2-b61d-4d9a-8cdc-73484590f81f",
+            "rank": 3,
+            "score": 60,
+            "zone": "World|Africa|Uganda",
+            "team": null
+        },
+        {
+            "participant": "af30b7a1-fc37-485f-94bf-f00e39805d8c",
+            "rank": 4,
+            "score": 59,
+            "zone": "World|Europe|Croatia",
+            "team": null
+        },
+        {
+            "participant": "9da54743-020c-4e87-82b9-1dad80f8162d",
+            "rank": 5,
+            "score": 58,
+            "zone": "World|Europe|France|Bretagne|Finistère",
+            "team": null
+        },
+        {
+            "participant": "05477e79-25fd-48c2-84c7-e1621aa46517",
+            "rank": 6,
+            "score": 57,
+            "zone": "World|Europe|Germany|Sachsen|Dresden",
+            "team": null
+        },
+        {
+            "participant": "961d1145-8c7b-48c3-9191-0d1d91e44a4a",
+            "rank": 7,
+            "score": 56,
+            "zone": "World|Europe|Germany|Niedersachsen|Oldenburg",
+            "team": null
+        },
+        {
+            "participant": "d0a811b4-5611-4948-8865-03c9d252bcf4",
+            "rank": 8,
+            "score": 55,
+            "zone": "World|Europe|France|Île-de-France|Paris",
+            "team": null
+        },
+        {
+            "participant": "1336b019-0d7d-43f7-b227-ff336f8b7140",
+            "rank": 9,
+            "score": 54,
+            "zone": "World|Europe|Portugal|Norte",
+            "team": null
+        },
+        {
+            "participant": "4d85c941-0242-4f9f-a6d4-ee7772d95e82",
+            "rank": 10,
+            "score": 53,
+            "zone": "World|Europe|Switzerland|Bern",
+            "team": null
+        }
+    ],
+    "scoreUnit": "point",
+    "teams": []
+}
+```
+
+If a `compMatchId` is invalid (or the match information is not available), the response will contain a `404` response code.

--- a/docs/core/records/map-record.md
+++ b/docs/core/records/map-record.md
@@ -20,7 +20,7 @@ Gets a single map record using its primary identifier.
 ---
 
 **Remarks**:
-- This endpoint only accepts a `mapRecordId` - to retrieve it, use the map records endpoint.
+- This endpoint only accepts a `mapRecordId` - to retrieve it, you can use the [map records endpoint](/core/records/map-records).
 
 ---
 

--- a/docs/core/records/map-records.md
+++ b/docs/core/records/map-records.md
@@ -24,7 +24,7 @@ Gets map records for a set of maps and a set of accounts.
 ---
 
 **Remarks**:
-- This endpoint only accepts `mapId`s - to translate `mapUid`s to `mapId`s, use the map info endpoint.
+- This endpoint only accepts `mapId`s - to translate `mapUid`s to `mapId`s, you can use the [map info endpoint](/core/maps/info).
 
 ---
 


### PR DESCRIPTION
Added a bunch of competition endpoints, moved the match-related ones into their own category and added challenge endpoints.
Also a few smaller changes, like proper links to the map info routes for map records.

For some reason the sub-category sorting is a bit messed up - any reason why that's not alphabetical? @codecat 
![grafik](https://user-images.githubusercontent.com/17618532/217389153-ff9cf10e-45b0-48e6-a276-88c6b2a3c3a2.png)
