### PR TITLE
Change max `get competition leaderboard` length to 255

### DIFF
--- a/docs/competition/competitions/leaderboard.md
+++ b/docs/competition/competitions/leaderboard.md
@@ -16,7 +16,7 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of competitions to retrieve (maximum 100)
+      description: The number of competitions to retrieve (maximum 255)
       required: false
       default: 10
     - name: offset


### PR DESCRIPTION
Max 255 length on the `get competition leaderboard` instead of 100. 
At 256 this error is given:
```json
{
    "exception": true,
    "trace_id": "Root=1-64550bfe-68ca62d6627848134da58d86"
}
```