### PR TITLE
Refactor min, max and default values for all endpoints

### DIFF
--- a/docs/competition/challenges/challenges.md
+++ b/docs/competition/challenges/challenges.md
@@ -11,12 +11,15 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of challenges to retrieve (10 by default)
+      description: The number of challenges to retrieve
       required: false
+      default: 10
+      max: 100
     - name: offset
       type: integer
       description: The number of challenges to skip
       required: false
+      default: 0
 ---
 
 Gets a list of challenges.

--- a/docs/competition/challenges/leaderboard.md
+++ b/docs/competition/challenges/leaderboard.md
@@ -18,10 +18,13 @@ parameters:
       type: integer
       description: The number of leaderboard entries to retrieve
       required: false
+      default: 10
+      max: 100
     - name: offset
       type: integer
       description: The number of leaderboard entries to skip
       required: false
+      default: 0
 ---
 
 Gets leaderboard entries for a challenge ID.

--- a/docs/competition/challenges/map-records.md
+++ b/docs/competition/challenges/map-records.md
@@ -20,12 +20,15 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of records to retrieve (10 by default)
+      description: The number of records to retrieve
       required: false
+      default: 10
+      max: 100
     - name: offset
       type: integer
       description: The number of records to skip
       required: false
+      default: 0
 ---
 
 Gets map records for a challenge ID.

--- a/docs/competition/club-competitions/club-competitions.md
+++ b/docs/competition/club-competitions/club-competitions.md
@@ -13,10 +13,13 @@ parameters:
       type: integer
       description: The number of competitions to retrieve
       required: false
+      default: 0
+      maximum: 100
     - name: offset
       type: integer
       description: The number of competitions to skip
       required: false
+      default: 0
 ---
 
 Gets a list of competitions in clubs the current user is a member of.

--- a/docs/competition/competitions/competitions.md
+++ b/docs/competition/competitions/competitions.md
@@ -13,10 +13,13 @@ parameters:
       type: integer
       description: The number of competitions to retrieve (maximum 100)
       required: false
+      default: 10
+      max: 100
     - name: offset
       type: integer
       description: The number of competitions to skip
       required: false
+      default: 0
 ---
 
 Gets a list of competitions.

--- a/docs/competition/competitions/leaderboard.md
+++ b/docs/competition/competitions/leaderboard.md
@@ -16,9 +16,10 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of participants to retrieve (maximum 255)
+      description: The number of participants to retrieve
       required: false
       default: 10
+      max: 255
     - name: offset
       type: integer
       description: The number of participants to skip

--- a/docs/competition/matches/matches-for-round.md
+++ b/docs/competition/matches/matches-for-round.md
@@ -18,10 +18,13 @@ parameters:
       type: integer
       description: The number of matches to retrieve
       required: true
+      default: 10
+      max: 100
     - name: offset
       type: integer
       description: The number of matches to skip
       required: false
+      default: 0
 ---
 
 Gets matches for a given round in a competition.

--- a/docs/competition/matches/participants.md
+++ b/docs/competition/matches/participants.md
@@ -16,12 +16,15 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of participants to retrieve (10 by default)
+      description: The number of participants to retrieve
       required: false
+      default: 10
+      max: 255
     - name: offset
       type: integer
       description: The number of participants to skip
       required: false
+      default: 0
 ---
 
 Gets players for a given competition match ID.

--- a/docs/competition/matches/results.md
+++ b/docs/competition/matches/results.md
@@ -16,12 +16,15 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of results to retrieve (10 by default)
+      description: The number of results to retrieve
       required: false
+      default: 10
+      max: 255
     - name: offset
       type: integer
       description: The number of results to skip
       required: false
+      default: 0
 ---
 
 Gets results for a given competition match ID.

--- a/docs/core/accounts/display-names.md
+++ b/docs/core/accounts/display-names.md
@@ -11,8 +11,9 @@ parameters:
   query:
     - name: accountIdList
       type: string
-      description: A comma-separated list of account IDs (maximum 50)
+      description: A comma-separated list of account IDs
       required: true
+      max: 50 account IDs
 ---
 
 Gets player display names from account IDs.
@@ -21,7 +22,6 @@ Gets player display names from account IDs.
 
 **Remarks**:
 - This endpoint is only accessible with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts). If you encounter `401` errors using a dedicated server account, switch to using a Ubisoft account.
-- The API returns a `400` error if more than 50 account IDs are requested.
 
 ---
 

--- a/docs/live/clubs/activities.md
+++ b/docs/live/clubs/activities.md
@@ -33,7 +33,7 @@ Gets a list of club activities, including news, rooms, campaigns and others.
 ---
 
 **Remarks**:
-- For clubs you are not an admin of, `active` needs to be set to `true` - because only admins are allowed to see disabled activities. Otherwise you'll get an error complaining that you're not a member/admin of the club.
+- For clubs you are not an admin of, `active` needs to be set to `true` because only admins are allowed to see disabled activities. Otherwise you'll get an error complaining that you're not a member/admin of the club.
 
 ---
 

--- a/docs/live/leaderboards/position.md
+++ b/docs/live/leaderboards/position.md
@@ -13,6 +13,7 @@ parameters:
       type: string
       description: The UID of the map
       required: true
+      max: 50 map UIDs
   query:
     - name: score
       type: integer

--- a/docs/live/leaderboards/surround.md
+++ b/docs/live/leaderboards/surround.md
@@ -21,10 +21,12 @@ parameters:
       type: integer
       description: The amount of records to return that are lower than the requested score
       required: true
+      max: 1
     - name: upper
       type: integer
       description: The amount of records to return that are higher than the requested score
       required: true
+      max: 1
   query:
     - name: score
       type: integer

--- a/docs/live/leaderboards/top.md
+++ b/docs/live/leaderboards/top.md
@@ -20,8 +20,10 @@ parameters:
   query:
     - name: length
       type: integer
-      description: The number of records to retrieve (5 by default, 100 is the maximum)
+      description: The number of records to retrieve
       required: false
+      default: 5
+      max: 100
     - name: onlyWorld
       type: boolean
       description: Whether to only retrieve records from the world leaderboard
@@ -30,6 +32,7 @@ parameters:
       type: integer
       description: The number of records to skip
       required: false
+      default: 0
 ---
 
 Gets surrounding records for a score on a map's leaderboard.

--- a/docs/live/maps/info-multiple.md
+++ b/docs/live/maps/info-multiple.md
@@ -11,8 +11,9 @@ parameters:
   query:
     - name: mapUidList
       type: string
-      description: A comma-separated list of map UIDs (maximum 100)
+      description: A comma-separated list of map UIDs
       required: true
+      max: 100 map UIDs
 ---
 
 Gets information about multiple maps from their UIDs.
@@ -21,7 +22,6 @@ Gets information about multiple maps from their UIDs.
 
 **Remarks**:
 - Invalid UIDs will be ignored in the result without any visible errors.
-- The API returns a `400` error if more than 100 map UIDs are requested.
 
 ---
 

--- a/views/index/api-param.php
+++ b/views/index/api-param.php
@@ -7,10 +7,20 @@
 		<span class="has-text-danger" title="Required">*</span>
 	<?php } ?>
 
-	<?php if (isset($item['default'])) { ?>
-		<ul><li>
-			<span>Default:</span>
-			<code><?= Nin\Html::encode($item['default']) ?></code>
-		</li></ul>
+	<?php if (isset($item['default']) || isset($item['min']) || isset($item['max'])) { ?>
+		<div class="is-size-6 has-text-grey mt-1">
+			<?php if (isset($item['min'])) { ?>
+				<span>Minimum:</span>
+				<code><?= Nin\Html::encode($item['min']) ?></code>
+			<?php } ?>
+			<?php if (isset($item['max'])) { ?>
+				<span>Maximum:</span>
+				<code><?= Nin\Html::encode($item['max']) ?></code>
+			<?php } ?>
+			<?php if (isset($item['default'])) { ?>
+				<span>Default:</span>
+				<code><?= Nin\Html::encode($item['default']) ?></code>
+			<?php } ?>
+		</div>
 	<?php } ?>
 </li>


### PR DESCRIPTION
- Went through all endpoints and checked for obvious limits to document.
- Added a more structured way of displaying minimum, maximum and default values (open for visual changes, I just went with something simple that should always work and doesn't take much space), see screenshot for an example.

![image](https://github.com/openplanet-nl/nadeoapi-docs/assets/17618532/bba6efe2-f189-4dea-809c-bad1c6e88de9)
