### PR TITLE
Add documentation for getting items from upload activities

### DIFF
--- a/docs/live/clubs/upload-by-id.md
+++ b/docs/live/clubs/upload-by-id.md
@@ -57,8 +57,8 @@ GET https://live-services.trackmania.nadeo.live/api/token/club/42175/bucket/3444
         },
         ...
         {
-            "itemId":"XoBSwvm1Ao_diasEK023Z9bIS40",
-            "position":54,
+            "itemId":"rRYRLq9YtI83LA53XbrZ2Bm4Kqg",
+            "position":9,
             "description":"",
             "mediaUrls":[]
         }

--- a/docs/live/clubs/upload-by-id.md
+++ b/docs/live/clubs/upload-by-id.md
@@ -36,6 +36,7 @@ Gets the maps, items, or skins in a specific upload activity.
 
 **Remarks**:
 - The returned bucket will have one of three types : `map-upload`, `skin-upload`, or `item-upload`. These relate to club track uploads, skin uploads and item collection activities, respectively.
+- The primary identifier for items in the returned bucket is their `itemId`. For maps this will be a `mapUid` and for skins this is a `skinID`.
 
 ---
 

--- a/docs/live/clubs/upload-by-id.md
+++ b/docs/live/clubs/upload-by-id.md
@@ -1,0 +1,79 @@
+---
+name: Get club upload activity by ID
+
+url: https://live-services.trackmania.nadeo.live
+method: GET
+route: /api/token/club/{clubID}/bucket/{bucketID}?length={length}&offset={offset}
+
+audience: NadeoLiveServices
+
+parameters:
+  path:
+    - name: clubID
+      type: integer
+      description: The ID of the club the upload activity belongs to
+      required: true
+    - name: bucketID
+      type: integer
+      description: The ID of the upload activity to be requested
+      required: true
+  query:
+    - name: length
+      type: integer
+      description: The number of items to retrieve
+      required: false
+      default: 10
+    - name: offset
+      type: integer
+      description: The number of items to skip
+      required: false
+      default: 0
+---
+
+Gets the maps, items, or skins in a specific upload activity.
+
+---
+
+**Remarks**:
+- The returned bucket will have one of three types : `map-upload`, `skin-upload`, or `item-upload`. These relate to club track uploads, skin uploads and item collection activities, respectively.
+
+---
+
+**Example request**:
+```plain
+GET https://live-services.trackmania.nadeo.live/api/token/club/42175/bucket/344426
+```
+
+**Example response**:
+```json
+{
+    "type":"map-upload",
+    "bucketItemList":[
+        {
+            "itemId":"41O6sDRjgRSVzahozZ_UmYwSU_i",
+            "position":0,
+            "description":"",
+            "mediaUrls":[]
+        },
+        ...
+        {
+            "itemId":"XoBSwvm1Ao_diasEK023Z9bIS40",
+            "position":54,
+            "description":"",
+            "mediaUrls":[]
+        }
+    ],
+    "bucketItemCount":55,
+    "popularityLevel":0,
+    "popularityValue":0,
+    "mediaUrl":"",
+    "mediaTheme":"",
+    "creationTimestamp":1673276709,
+    "creatorAccountId":"fc8467b8-b253-457f-b8bb-3bbd2bb5bfdd",
+    "latestEditorAccountId":"fc8467b8-b253-457f-b8bb-3bbd2bb5bfdd",
+    "id":344426,
+    "clubId":42175,
+    "clubName":"$Z$f72ArEyeses$fff\u0027 $888Club",
+    "name":"Randomly Generated G"
+}
+```

--- a/docs/live/clubs/uploads.md
+++ b/docs/live/clubs/uploads.md
@@ -1,5 +1,5 @@
 ---
-name: Get club asset activities
+name: Get club upload activities
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
@@ -11,25 +11,25 @@ parameters:
   path:
     - name: bucketType
       type: string
-      description: The type of assets to retrieve (see below for accepted values)
+      description: The type of upload activity to retrieve (see below for accepted values)
       required: true
   query:
     - name: length
       type: integer
-      description: The number of assets to retrieve
+      description: The number of upload activities to retrieve
       required: true
     - name: offset
       type: integer
-      description: The number of assets to skip
+      description: The number of upload activities to skip
       required: true
 ---
 
-Gets a list of club-related asset activities (where players can upload maps, skins and items).
+Gets a list of club-related upload activities (where players can upload maps, skins and items).
 
 ---
 
 **Remarks**:
-- There are three types of asset activities you can retrieve: `map-upload`, `skin-upload` and `item-upload`. These relate to club campaign maps, club skins and club items, respectively.
+- There are three types of upload activities you can retrieve: `map-upload`, `skin-upload` and `item-upload`. These relate to club track uploads, skin uploads and item collection activities, respectively.
 
 ---
 


### PR DESCRIPTION
- Added a page describing the api endpoint for getting maps from map/skin/item upload activities
- Changed the phrasing of upload activities from 'asset' to 'upload activity' in the page about getting upload activities by type