### PR TITLE
Added categories

### DIFF
--- a/components/Controller.php
+++ b/components/Controller.php
@@ -58,6 +58,7 @@ class Controller extends Nin\Controller
 
 						$roots[] = [
 							'type' => 'root',
+							'category' => $root_index_page->meta['category'] ?? '',
 							'name' => $root_index_page->meta['name'] ?? str_replace('-', ' ', ucfirst($root)),
 							'icon' => $index_page->meta['icon'] ?? '',
 							'path' => $root,
@@ -76,8 +77,9 @@ class Controller extends Nin\Controller
 
 						$dirs[] = [
 							'type' => 'dir',
+							'category' => $dir_index_page->meta['category'] ?? '',
 							'name' => $dir_index_page->meta['name'] ?? str_replace('-', ' ', ucfirst($dir)),
-							'icon' => $index_page->meta['icon'] ?? '',
+							'icon' => $dir_index_page->meta['icon'] ?? '',
 							'path' => $dir,
 							'children' => $this->getPageIndexInternal($docs_dir . '/' . $dir),
 						];
@@ -95,6 +97,7 @@ class Controller extends Nin\Controller
 
 						$pages[] = [
 							'type' => 'page',
+							'category' => $page->meta['category'] ?? '',
 							'name' => $page->getName(),
 							'icon' => $page->meta['icon'] ?? '',
 							'path' => $page_name,
@@ -123,6 +126,7 @@ class Controller extends Nin\Controller
 			if ($fileinfo->isDir()) {
 				$dirs[] = [
 					'type' => 'dir',
+					'category' => '',
 					'name' => str_replace('-', ' ', ucfirst($filename)),
 					'icon' => '',
 					'path' => $filename,
@@ -143,6 +147,7 @@ class Controller extends Nin\Controller
 
 			$pages[] = [
 				'type' => 'page',
+				'category' => $page->meta['category'] ?? '',
 				'name' => $page->getName(),
 				'icon' => $page->meta['icon'] ?? '',
 				'path' => $filename,
@@ -155,9 +160,9 @@ class Controller extends Nin\Controller
 
 	public function getPageIndex()
 	{
-		return nf_cache()->take('page_index', 3600, function() {
+		//return nf_cache()->take('page_index', 3600, function() {
 			return $this->getPageIndexInternal();
-		});
+		//});
 	}
 
 	public function getPageIndexInfo(string $path)

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -1,5 +1,7 @@
 ---
 name: Authentication
+category: general
+icon: fa-lock
 pages:
   - ubi
   - dedi

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -1,5 +1,6 @@
 ---
 name: Core API
+category: reference
 ---
 
 # Core API

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,6 @@
 ---
 icon: "fa-book"
+category: "general"
 ---
 
 # Glossary

--- a/docs/live/index.md
+++ b/docs/live/index.md
@@ -1,5 +1,6 @@
 ---
 name: Live API
+category: reference
 ---
 
 # Live API

--- a/docs/meet/index.md
+++ b/docs/meet/index.md
@@ -1,5 +1,6 @@
 ---
 name: Meet API
+category: reference
 ---
 
 # Meet API

--- a/views/menu/menu.php
+++ b/views/menu/menu.php
@@ -13,7 +13,7 @@
 		]);
 
 		foreach ($index as $item) {
-			if ($item['type'] != 'page') {
+			if ($item['category'] != 'general') {
 				continue;
 			}
 			echo $this->renderPartial('/menu/item', [
@@ -28,7 +28,7 @@
 	<ul class="menu-list">
 		<?php
 		foreach ($index as $item) {
-			if ($item['type'] != 'dir') {
+			if ($item['category'] != 'reference') {
 				continue;
 			}
 			echo $this->renderPartial('/menu/item', [


### PR DESCRIPTION
Use category strings in `menu.cpp` instead of hardcoded `page` for general and `dir` for reference. This allows us to put `auth` back in the general category even though it's a directory.