### PR TITLE
Update the error example for the live get map info endpoint

### DIFF
--- a/docs/live/maps/add-favorite.md
+++ b/docs/live/maps/add-favorite.md
@@ -35,8 +35,4 @@ POST https://live-services.trackmania.nadeo.live/api/token/map/favorite/EgUgXeBV
 
 A successful response has no content and a `204` response code.
 
-Example response if the requested map does not exist:
-
-```json
-["map:error-notFound"]
-```
+If you try to submit a map that doesn't exist, you will also get a response with no content and a `204` response code.

--- a/docs/live/maps/add-favorite.md
+++ b/docs/live/maps/add-favorite.md
@@ -33,6 +33,6 @@ POST https://live-services.trackmania.nadeo.live/api/token/map/favorite/EgUgXeBV
 
 **Example response**:
 
-A successful response has no content and a `204` response code.
+Both successful and unsuccessful responses have no content and return a `204` response code.
 
-If you try to submit a map that doesn't exist, you will also get a response with no content and a `204` response code.
+An invalid `mapUid` results in a `500` response code with an error object in the response body.

--- a/docs/live/maps/info.md
+++ b/docs/live/maps/info.md
@@ -63,7 +63,9 @@ GET https://live-services.trackmania.nadeo.live/api/token/map/QleO8OiNAkIXrZs6r0
 Example response if the requested map does not exist:
 
 ```json
-["map:error-notFound"]
+{
+    "error": "NotFoundHttpException",
+    "message": "",
+    "traceId": "Root=1-68b47f2d-6c4f97f5124aa8ab32d2914e"
+}
 ```
-
-Note: Be careful to check the response type; a valid track will return an object, but an invalid track will return an array with a string in it.

--- a/docs/live/maps/remove-favorite.md
+++ b/docs/live/maps/remove-favorite.md
@@ -34,14 +34,4 @@ POST https://live-services.trackmania.nadeo.live/api/token/map/favorite/EgUgXeBV
 
 A successful response has no content and a `204` response code.
 
-Example response if the requested map does not exist:
-
-```json
-["map:error-notFound"]
-```
-
-Example response if the requested map is not among your favorites:
-
-```json
-["mapFavorite:error-notFound"]
-```
+If you try to remove a map that doesn't exist or a map that isn't among your favorites, you will also get a response with no content and a `204` response code.

--- a/docs/live/maps/remove-favorite.md
+++ b/docs/live/maps/remove-favorite.md
@@ -32,6 +32,6 @@ POST https://live-services.trackmania.nadeo.live/api/token/map/favorite/EgUgXeBV
 
 **Example response**:
 
-A successful response has no content and a `204` response code.
+Both successful and unsuccessful responses (including requests for maps that are not part of your favorites) have no content and return a `204` response code.
 
-If you try to remove a map that doesn't exist or a map that isn't among your favorites, you will also get a response with no content and a `204` response code.
+An invalid `mapUid` results in a `500` response code with an error object in the response body.


### PR DESCRIPTION
This endpoint used to return an array, but now returns an object with an error and a message.

Note regarding the example: I'm not knowledgable enough to know if I should obfuscate that traceID. I doubt that it's important, but I'm mentioning it in case someone has a better idea.