### PR TITLE
Add Core favorites endpoints

### DIFF
--- a/docs/core/maps/add-favorite.md
+++ b/docs/core/maps/add-favorite.md
@@ -52,6 +52,6 @@ POST https://prod.trackmania.core.nadeo.online/maps/favorites
 null
 ```
 
-Both successful and unsuccessful responses (including requests for maps that don't exist) have no content and return a `200` response code.
+Both successful and unsuccessful responses (including requests for maps that don't exist) return a `200` response code.
 
 An invalid `mapUid` results in a `400` response code with an error object in the response body.

--- a/docs/core/maps/add-favorite.md
+++ b/docs/core/maps/add-favorite.md
@@ -15,7 +15,7 @@ parameters:
       required: true
 ---
 
-The request body contains the map to add, identified by its mapUid
+The request body contains the map to add, identified by its mapUid:
 
 ```json
 {

--- a/docs/core/maps/add-favorite.md
+++ b/docs/core/maps/add-favorite.md
@@ -1,0 +1,57 @@
+---
+name: Add favorite map
+
+url: https://prod.trackmania.core.nadeo.online
+method: POST
+route: /maps/favorites
+
+audience: NadeoServices
+
+parameters:
+  body:
+    - name: mapUid
+      type: string
+      description: The UID of the map
+      required: true
+---
+
+The request body contains the map to add, identified by its mapUid
+
+```json
+{
+  "mapUid": "{mapUid}"
+}
+```
+
+Adds a map to your authenticated account's favorites.
+
+---
+
+**Remarks**:
+
+- This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
+- This endpoint serves the same purpose as the [Live API's Add favorite map endpoint](/live/maps/add-favorite), but the request format is different.
+
+---
+
+**Example request**:
+
+```plain
+POST https://prod.trackmania.core.nadeo.online/maps/favorites
+```
+
+```json
+{
+  "mapUid": "KRelvYHRjEQoqnkJ_Th8FLKzTsg"
+}
+```
+
+**Example response**:
+
+```plain
+null
+```
+
+Both successful and unsuccessful responses (including requests for maps that don't exist) have no content and return a `200` response code.
+
+An invalid `mapUid` results in a `400` response code with an error object in the response body.

--- a/docs/core/maps/favorites-uids.md
+++ b/docs/core/maps/favorites-uids.md
@@ -1,0 +1,57 @@
+---
+name: Get favorite maps by UIDs
+
+url: https://prod.trackmania.core.nadeo.online
+method: GET
+route: /maps/favorites/by-map-uids?mapUidList={mapUidList}
+
+audience: NadeoServices
+
+parameters:
+  query:
+    - name: mapUidList
+      type: string
+      description: A comma-separated list of map UIDs
+      required: true
+---
+
+Gets maps in your authenticated account's favorite tracks via their UIDs.
+
+---
+
+**Remarks**:
+
+- This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
+- The `timestamp` field is when the map was added to your favorite tracks.
+
+---
+
+**Example request**:
+
+```plain
+GET https://prod.trackmania.core.nadeo.online/maps/favorites/by-map-uids?mapUidList=WGWbB_OQnMk3RfD1b3laxonXJQh,KRelvYHRjEQoqnkJ_Th8FLKzTsg
+```
+
+**Example response**:
+
+```json
+{
+  "mapFavoriteList": [
+    {
+      "accountId": "69f31664-4252-48e0-a433-024c49caee8c",
+      "mapUid": "KRelvYHRjEQoqnkJ_Th8FLKzTsg",
+      "timestamp": "2026-02-13T18:12:03+00:00"
+    },
+    {
+      "accountId": "69f31664-4252-48e0-a433-024c49caee8c",
+      "mapUid": "WGWbB_OQnMk3RfD1b3laxonXJQh",
+      "timestamp": "2026-02-13T21:24:28+00:00"
+    }
+  ],
+  "count": 2
+}
+```
+
+If a map can't be found or isn't part of your favorites, it will be omitted from the response.
+
+An invalid `mapUid` results in a `400` response code with an error object in the response body.

--- a/docs/core/maps/favorites.md
+++ b/docs/core/maps/favorites.md
@@ -1,0 +1,73 @@
+---
+name: Get favorite maps
+
+url: https://prod.trackmania.core.nadeo.online
+method: GET
+route: /maps/favorites?offset={offset}&length={length}&sort={sort}&order={order}&mapTypeList={mapTypeList}&playable={playable}&onlyMine={onlyMine}
+
+audience: NadeoServices
+
+parameters:
+  query:
+    - name: offset
+      type: integer
+      description: The number of maps to skip
+      required: true
+    - name: length
+      type: integer
+      description: The number of maps to retrieve
+      required: true
+      min: 1
+    - name: sort
+      type: string
+      description: The sorting of the maps
+      default: "date"
+    - name: order
+      type: string
+      description: The order of the maps based on the sorting
+      default: "desc"
+    - name: mapTypeList
+      type: string
+      description: The map type filter separated by commas
+    - name: playable
+      type: boolean
+      description: Whether the map is validated and playable
+    - name: onlyMine
+      type: boolean
+      description: Whether the map was created by the current authenticated account
+---
+
+Retrieves your authenticated account's favorite tracks.
+
+---
+
+**Remarks**:
+
+- This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
+- When no `mapTypeList` filter is applied, all available maps are returned regardless of their type.
+- See the [glossary](/glossary#map-type) for examples of supported map types.
+- The `timestamp` field is when the map was added to your favorite tracks.
+- This endpoint behaves similarly to the [Live API's Get favorite map endpoint](/live/maps/favorites), but the response data model is different, with the Live endpoint also including the map information.
+
+---
+
+**Example request**:
+
+```plain
+GET https://prod.trackmania.core.nadeo.online/maps/favorites?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\\TM_Race&playable=true&onlyMine=false
+```
+
+**Example response**:
+
+```json
+{
+  "mapFavoriteList": [
+    {
+      "accountId": "69f31664-4252-48e0-a433-024c49caee8c",
+      "mapUid": "KRelvYHRjEQoqnkJ_Th8FLKzTsg",
+      "timestamp": "2026-02-13T20:58:41+00:00"
+    }
+  ],
+  "count": 11
+}
+```

--- a/docs/core/maps/favorites.md
+++ b/docs/core/maps/favorites.md
@@ -55,7 +55,7 @@ Retrieves your authenticated account's favorite tracks.
 **Example request**:
 
 ```plain
-GET https://prod.trackmania.core.nadeo.online/maps/favorites?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\\TM_Race&playable=true&onlyMine=false
+GET https://prod.trackmania.core.nadeo.online/maps/favorites?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\TM_Race&playable=true&onlyMine=false
 ```
 
 **Example response**:

--- a/docs/core/maps/favorites.md
+++ b/docs/core/maps/favorites.md
@@ -44,10 +44,11 @@ Retrieves your authenticated account's favorite tracks.
 **Remarks**:
 
 - This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
+- The `sort` parameter can be set to `"date"` (when the map was added to your favorite tracks) or `"name"` (the map name).
 - When no `mapTypeList` filter is applied, all available maps are returned regardless of their type.
 - See the [glossary](/glossary#map-type) for examples of supported map types.
 - The `timestamp` field is when the map was added to your favorite tracks.
-- This endpoint behaves similarly to the [Live API's Get favorite map endpoint](/live/maps/favorites), but the response data model is different, with the Live endpoint also including the map information.
+- This endpoint behaves similarly to the [Live API's Get favorite map endpoint](/live/maps/favorites), but the response data model is different, with the Live endpoint also including additional map information.
 
 ---
 

--- a/docs/core/maps/remove-favorite.md
+++ b/docs/core/maps/remove-favorite.md
@@ -1,0 +1,57 @@
+---
+name: Remove favorite map
+
+url: https://prod.trackmania.core.nadeo.online
+method: DELETE
+route: /maps/favorites
+
+audience: NadeoServices
+
+parameters:
+  body:
+    - name: mapUid
+      type: string
+      description: The UID of the map
+      required: true
+---
+
+The request body contains the map to remove, identified by its mapUid
+
+```json
+{
+  "mapUid": "{mapUid}"
+}
+```
+
+Removes a map from your authenticated account's favorites.
+
+---
+
+**Remarks**:
+
+- This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
+- This endpoint serves the same purpose as the [Live API's Remove favorite map endpoint](/live/maps/remove-favorite), but the request format is different.
+
+---
+
+**Example request**:
+
+```plain
+DELETE https://prod.trackmania.core.nadeo.online/maps/favorites
+```
+
+```json
+{
+  "mapUid": "KRelvYHRjEQoqnkJ_Th8FLKzTsg"
+}
+```
+
+**Example response**:
+
+```plain
+null
+```
+
+Both successful and unsuccessful responses (including requests for maps that are not part of your favorites or don't exist) have no content and return a `200` response code.
+
+An invalid `mapUid` results in a `400` response code with an error object in the response body.

--- a/docs/core/maps/remove-favorite.md
+++ b/docs/core/maps/remove-favorite.md
@@ -15,7 +15,7 @@ parameters:
       required: true
 ---
 
-The request body contains the map to remove, identified by its mapUid
+The request body contains the map to remove, identified by its mapUid:
 
 ```json
 {

--- a/docs/core/maps/remove-favorite.md
+++ b/docs/core/maps/remove-favorite.md
@@ -52,6 +52,6 @@ DELETE https://prod.trackmania.core.nadeo.online/maps/favorites
 null
 ```
 
-Both successful and unsuccessful responses (including requests for maps that are not part of your favorites or don't exist) have no content and return a `200` response code.
+Both successful and unsuccessful responses (including requests for maps that are not part of your favorites or don't exist) return a `200` response code.
 
 An invalid `mapUid` results in a `400` response code with an error object in the response body.

--- a/docs/live/maps/favorites.md
+++ b/docs/live/maps/favorites.md
@@ -3,7 +3,7 @@ name: Get favorite maps
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/map/favorite?offset={offset}&length={length}&sort={sort}&order={order}&mapTypeList={mapTypeList}&playable={playable}
+route: /api/token/map/favorite?offset={offset}&length={length}&sort={sort}&order={order}&mapTypeList={mapTypeList}&playable={playable}&onlyMine={onlyMine}
 
 audience: NadeoLiveServices
 parameters:
@@ -31,6 +31,9 @@ parameters:
     - name: playable
       type: boolean
       description: Whether the map is validated and playable
+    - name: onlyMine
+      type: boolean
+      description: Whether the map was created by the current authenticated account
 ---
 
 Retrieves your authenticated account's favorite tracks along with their information.
@@ -48,7 +51,7 @@ Retrieves your authenticated account's favorite tracks along with their informat
 **Example request**:
 
 ```plain
-GET https://live-services.trackmania.nadeo.live/api/token/map/favorite?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\\TM_Race&playable=true
+GET https://live-services.trackmania.nadeo.live/api/token/map/favorite?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\\TM_Race&playable=true&onlyMine=false
 ```
 
 **Example response**:

--- a/docs/live/maps/favorites.md
+++ b/docs/live/maps/favorites.md
@@ -43,6 +43,7 @@ Retrieves your authenticated account's favorite tracks along with their informat
 **Remarks**:
 
 - This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
+- The `sort` parameter can be set to `"date"` (when the map was added to your favorite tracks) or `"name"` (the map name).
 - When no `mapTypeList` filter is applied, all available maps are returned regardless of their type.
 - See the [glossary](/glossary#map-type) for examples of supported map types.
 

--- a/docs/live/maps/favorites.md
+++ b/docs/live/maps/favorites.md
@@ -52,7 +52,7 @@ Retrieves your authenticated account's favorite tracks along with their informat
 **Example request**:
 
 ```plain
-GET https://live-services.trackmania.nadeo.live/api/token/map/favorite?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\\TM_Race&playable=true&onlyMine=false
+GET https://live-services.trackmania.nadeo.live/api/token/map/favorite?offset=0&length=1&sort=date&order=desc&mapTypeList=Trackmania\TM_Race&playable=true&onlyMine=false
 ```
 
 **Example response**:


### PR DESCRIPTION
Found by using Wireshark, these are the favorites endpoints used by the game. 3 of them work similarly to their Live counterpart, but the request or response is different. The UID endpoint seems to be used to verify if a map is part of your favorites to show "Remove from your favorites" in the pause menu

I also tested if the Live favorites endpoint supported `onlyMine`, and it does, so I added it as a parameter in the documentation.