### PR TITLE
change ambiguous activityId / campaignId / roomId

### DIFF
--- a/docs/live/club-management/add-to-upload.md
+++ b/docs/live/club-management/add-to-upload.md
@@ -3,7 +3,7 @@ name: Add items to club upload activity
 
 url: https://live-services.trackmania.nadeo.live
 method: POST
-route: /api/token/club/{clubId}/bucket/{bucketId}/add
+route: /api/token/club/{clubId}/bucket/{activityId}/add
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the upload activity belongs to
       required: true
-    - name: bucketId
+    - name: activityId
       type: integer
-      description: The ID of the upload activity where the items should be added
+      description: The activity ID of the upload activity where the items should be added
       required: true
   body:
     - name: itemIdList

--- a/docs/live/club-management/create-ranking.md
+++ b/docs/live/club-management/create-ranking.md
@@ -25,7 +25,7 @@ parameters:
       required: true
     - name: campaignId
       type: integer
-      description: The campaignID of a campaign from the club (see remarks below)
+      description: The campaignId of a campaign from the club (see remarks below)
     - name: folderId
       type: integer
       description: The ID of the folder where the ranking should be created
@@ -50,7 +50,7 @@ Creates a ranking in a club.
 
 - This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
 - The `useCase` parameter supports three cases: Current Quarterly Campaign (`"ranking-official"`), Daily Track / TOTD (`"ranking-daily"`), and Club Campaign (`"ranking-club"`).
-- When creating a Club Campaign ranking, it is required to set the `campaignId` parameter to the campaignID of a campaign from the club.
+- When creating a Club Campaign ranking, it is required to set the `campaignId` parameter to the campaignId of a campaign from the club.
 - If the club campaign is not a campaign from the club, or it does not exist, the ranking will be created, but an error will be displayed in-game when accessing the ranking.
 - See the [glossary](/glossary#club-folders) for more information about folders.
 

--- a/docs/live/club-management/create-ranking.md
+++ b/docs/live/club-management/create-ranking.md
@@ -25,7 +25,7 @@ parameters:
       required: true
     - name: campaignId
       type: integer
-      description: The campaignId of a campaign from the club (see remarks below)
+      description: The campaign ID of a campaign from the club (see remarks below)
     - name: folderId
       type: integer
       description: The ID of the folder where the ranking should be created
@@ -50,7 +50,7 @@ Creates a ranking in a club.
 
 - This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
 - The `useCase` parameter supports three cases: Current Quarterly Campaign (`"ranking-official"`), Daily Track / TOTD (`"ranking-daily"`), and Club Campaign (`"ranking-club"`).
-- When creating a Club Campaign ranking, it is required to set the `campaignId` parameter to the campaignId of a campaign from the club.
+- When creating a Club Campaign ranking, it is required to set the `campaignId` parameter to the campaign ID of a campaign from the club.
 - If the club campaign is not a campaign from the club, or it does not exist, the ranking will be created, but an error will be displayed in-game when accessing the ranking.
 - See the [glossary](/glossary#club-folders) for more information about folders.
 

--- a/docs/live/club-management/delete-activity.md
+++ b/docs/live/club-management/delete-activity.md
@@ -15,7 +15,7 @@ parameters:
       required: true
     - name: activityId
       type: integer
-      description: The ID of the activity to delete
+      description: The activity ID of the activity to delete
       required: true
 ---
 

--- a/docs/live/club-management/edit-activity.md
+++ b/docs/live/club-management/edit-activity.md
@@ -15,7 +15,7 @@ parameters:
       required: true
     - name: activityId
       type: integer
-      description: The ID of the activity to be edited
+      description: The activity ID of the activity to be edited
       required: true
   body:
     - name: name

--- a/docs/live/club-management/edit-campaign.md
+++ b/docs/live/club-management/edit-campaign.md
@@ -15,7 +15,7 @@ parameters:
       required: true
     - name: campaignId
       type: integer
-      description: The ID of the campaign to be edited
+      description: The campaign ID of the campaign to be edited
       required: true
   body:
     - name: name

--- a/docs/live/club-management/edit-map-review.md
+++ b/docs/live/club-management/edit-map-review.md
@@ -3,7 +3,7 @@ name: Edit club map review activity
 
 url: https://live-services.trackmania.nadeo.live
 method: POST
-route: /api/token/club/{clubId}/map-review/{mapReviewId}/edit
+route: /api/token/club/{clubId}/map-review/{activityId}/edit
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club where the map review activity should be created
       required: true
-    - name: mapReviewId
+    - name: activityId
       type: integer
-      description: The ID of the map review activity to be edited
+      description: The activity ID of the map review activity to be edited
       required: true
   body:
     - name: name

--- a/docs/live/club-management/edit-news.md
+++ b/docs/live/club-management/edit-news.md
@@ -3,7 +3,7 @@ name: Edit club news article
 
 url: https://live-services.trackmania.nadeo.live
 method: POST
-route: /api/token/club/{clubId}/news/{newsId}/edit
+route: /api/token/club/{clubId}/news/{activityId}/edit
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the news article belongs to
       required: true
-    - name: newsId
+    - name: activityId
       type: integer
-      description: The ID of the news article to be edited
+      description: The activity ID of the news article to be edited
       required: true
   body:
     - name: name

--- a/docs/live/club-management/edit-room.md
+++ b/docs/live/club-management/edit-room.md
@@ -3,7 +3,7 @@ name: Edit club room
 
 url: https://live-services.trackmania.nadeo.live
 method: POST
-route: /api/token/club/{clubId}/room/{roomId}/edit
+route: /api/token/club/{clubId}/room/{activityId}/edit
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the room belongs to
       required: true
-    - name: roomId
+    - name: activityId
       type: integer
-      description: The ID of the room to be edited
+      description: The activity ID of the room to be edited
       required: true
   body:
     - name: name

--- a/docs/live/club-management/remove-from-upload.md
+++ b/docs/live/club-management/remove-from-upload.md
@@ -3,7 +3,7 @@ name: Remove items from club upload activity
 
 url: https://live-services.trackmania.nadeo.live
 method: POST
-route: /api/token/club/{clubId}/bucket/{bucketId}/remove
+route: /api/token/club/{clubId}/bucket/{activityId}/remove
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the upload activity belongs to
       required: true
-    - name: bucketId
+    - name: activityId
       type: integer
-      description: The ID of the upload activity where the items should be removed from
+      description: The activity ID of the upload activity where the items should be removed from
       required: true
   body:
     - name: itemIdList

--- a/docs/live/clubs/campaign-by-id.md
+++ b/docs/live/clubs/campaign-by-id.md
@@ -3,7 +3,7 @@ name: Get club campaign by ID
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubID}/campaign/{campaignID}
+route: /api/token/club/{clubID}/campaign/{campaignId}
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the campaign belongs to
       required: true
-    - name: campaignID
+    - name: campaignId
       type: integer
-      description: The ID of the campaign to be requested
+      description: The campaign ID of the campaign to be requested
       required: true
 ---
 

--- a/docs/live/clubs/map-review-by-id.md
+++ b/docs/live/clubs/map-review-by-id.md
@@ -3,7 +3,7 @@ name: Get map review activity by ID
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubId}/map-review/{mapReviewId}
+route: /api/token/club/{clubId}/map-review/{activityId}
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the map review activity belongs to
       required: true
-    - name: mapReviewId
+    - name: activityId
       type: integer
-      description: The ID of the map review activity to be requested
+      description: The activity ID of the map review activity to be requested
       required: true
 ---
 

--- a/docs/live/clubs/news-by-id.md
+++ b/docs/live/clubs/news-by-id.md
@@ -3,7 +3,7 @@ name: Get club news by ID
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubId}/news/{newsId}
+route: /api/token/club/{clubId}/news/{activityId}
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the news belongs to
       required: true
-    - name: newsId
+    - name: activityId
       type: integer
-      description: The ID of the news to be requested
+      description: The activity ID of the news to be requested
       required: true
 ---
 

--- a/docs/live/clubs/room-by-id.md
+++ b/docs/live/clubs/room-by-id.md
@@ -3,7 +3,7 @@ name: Get club room by ID
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubID}/room/{roomID}
+route: /api/token/club/{clubID}/room/{activityId}
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the room belongs to
       required: true
-    - name: roomID
+    - name: activityId
       type: integer
-      description: The ID of the room to be requested
+      description: The activity ID of the room to be requested
       required: true
 ---
 

--- a/docs/live/clubs/room-join-link.md
+++ b/docs/live/clubs/room-join-link.md
@@ -3,7 +3,7 @@ name: Get club room join link
 
 url: https://live-services.trackmania.nadeo.live
 method: POST
-route: /api/token/club/{clubId}/room/{roomId}/join
+route: /api/token/club/{clubId}/room/{activityId}/join
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the room belongs to
       required: true
-    - name: roomId
+    - name: activityId
       type: integer
-      description: The ID of the room to be requested
+      description: The activity ID of the room to be requested
       required: true
 ---
 

--- a/docs/live/clubs/room-password.md
+++ b/docs/live/clubs/room-password.md
@@ -3,7 +3,7 @@ name: Get club room password
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubId}/room/{roomId}/get-password
+route: /api/token/club/{clubId}/room/{activityId}/get-password
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the room belongs to
       required: true
-    - name: roomId
+    - name: activityId 
       type: integer
-      description: The ID of the room to be requested
+      description: The activity ID of the room to be requested
       required: true
 ---
 

--- a/docs/live/clubs/upload-by-id.md
+++ b/docs/live/clubs/upload-by-id.md
@@ -3,7 +3,7 @@ name: Get club upload activity by ID
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubID}/bucket/{bucketID}?length={length}&offset={offset}
+route: /api/token/club/{clubID}/bucket/{activityId}?length={length}&offset={offset}
 
 audience: NadeoLiveServices
 
@@ -13,9 +13,9 @@ parameters:
       type: integer
       description: The ID of the club the upload activity belongs to
       required: true
-    - name: bucketID
+    - name: activityId
       type: integer
-      description: The ID of the upload activity to be requested
+      description: The activity ID of the upload activity to be requested
       required: true
   query:
     - name: length

--- a/docs/live/map-review/club-submitted.md
+++ b/docs/live/map-review/club-submitted.md
@@ -3,7 +3,7 @@ name: Get submitted maps to club map review
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubId}/map-review/{mapReviewId}/map/mine?length={length}&offset={offset}&withFeedback={withFeedback}&withMapInfo={withMapInfo}
+route: /api/token/club/{clubId}/map-review/{activityId}/map/mine?length={length}&offset={offset}&withFeedback={withFeedback}&withMapInfo={withMapInfo}
 
 audience: NadeoLiveServices
 parameters:
@@ -12,9 +12,9 @@ parameters:
       type: integer
       description: The ID of the club the map review activity belongs to
       required: true
-    - name: mapReviewId
+    - name: activityId
       type: integer
-      description: The ID of the map review activity
+      description: The activity ID of the map review activity
       required: true
   query:
     - name: length
@@ -44,7 +44,7 @@ Retrieves your maps submitted to a club map review activity.
 - This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
 - The data returned from this endpoint is largely the same data that can be accessed through the club on the [official website](https://trackmania.com).
 - If the `withFeedback` parameter is set to `false`, the `noteInfo` field in the response will be `null`. Similarly, if the `withMapInfo` parameter is set to `false`, the `map` field will be `null`.
-- The relevant `mapReviewId` can be retrieved using the [club activities endpoint](/live/clubs/activities).
+- The relevant `activityId` can be retrieved using the [club activities endpoint](/live/clubs/activities).
 - This endpoint is only useful for club activities. To retrieve maps submitted to Nadeo for official game modes, use the [submitted maps endpoint](/live/map-review/submitted).
 
 ---

--- a/docs/live/map-review/members-submissions.md
+++ b/docs/live/map-review/members-submissions.md
@@ -3,7 +3,7 @@ name: Get member submissions to club map review
 
 url: https://live-services.trackmania.nadeo.live
 method: GET
-route: /api/token/club/{clubId}/map-review/{mapReviewId}/map?offset={offset}&length={length}
+route: /api/token/club/{clubId}/map-review/{activityId}/map?offset={offset}&length={length}
 
 audience: NadeoLiveServices
 parameters:
@@ -12,9 +12,9 @@ parameters:
       type: integer
       description: The ID of the club the map review activity belongs to
       required: true
-    - name: mapReviewId
+    - name: activityId
       type: integer
-      description: The ID of the map review activity
+      description: The activity ID of the map review activity
       required: true
   query:
     - name: length
@@ -34,7 +34,7 @@ Retrieves map submissions of all club members to a club map review activity.
 **Remarks**:
 
 - This endpoint is only useful with tokens authenticated through Ubisoft user accounts (as opposed to dedicated server accounts).
-- The relevant `mapReviewId` can be retrieved using the [Get club activities endpoint](/live/clubs/activities).
+- The relevant `activityId` can be retrieved using the [Get club activities endpoint](/live/clubs/activities).
 - The data returned from this endpoint is largely the same data that can be accessed through the club's admin page on the [official website](https://trackmania.com).
 - The response data model is similar to the [submitted maps endpoint](/live/map-review/submitted), with this endpoint including additional map information accessible to admins, including player counts data, scores, playing time, and more.
 


### PR DESCRIPTION
The club activity request urls were previously using a notation where `{activity type}Id` was used to mean the `activityId` for an activity of that type, except for campaigns where `campaignId` did indeed mean the campaign's `campaignId` and not its `activityId`.
This was confusing since rooms used `roomId` to mean the room's `activityId` and not its `roomId`.

This pr changes the notation to use `activityId` whenever an activity ID is required, only leaving `campaignId` whenever a campaign ID is required.