### PR TITLE
Added optional trophyType parameter

### DIFF
--- a/docs/core/accounts/trophy-history.md
+++ b/docs/core/accounts/trophy-history.md
@@ -3,7 +3,7 @@ name: Get player trophy history
 
 url: https://prod.trackmania.core.nadeo.online
 method: GET
-route: /accounts/{accountId}/trophies?count={count}&offset={offset}
+route: /accounts/{accountId}/trophies?count={count}&offset={offset}&trophyType={trophyType}
 
 audience: NadeoServices
 
@@ -23,6 +23,11 @@ parameters:
       type: integer
       description: The number of entries to skip (looking back from the most recent)
       default: 0
+    - name: trophyType
+      type: integer
+      description: The level of trophy to filter for
+      min: 1
+      max: 9
 ---
 
 Gets a player's earned trophy history, sorted newest to oldest.


### PR DESCRIPTION
Adds the optional `trophyType` parameter to [`trophy-history`](https://webservices.openplanet.dev/core/accounts/trophy-history).

It's worth noting some trophy types are giving me internal server errors, which I can't explain:
<img width="1218" height="207" alt="image" src="https://github.com/user-attachments/assets/7524b48a-8063-463d-a77c-2242d755b5f5" />
